### PR TITLE
fix(npm): Properly escaping multi-word arguments

### DIFF
--- a/Enterwell.CI.Changelog.CLI.NPM/README.md
+++ b/Enterwell.CI.Changelog.CLI.NPM/README.md
@@ -51,7 +51,6 @@ These files are then used with our [Changelog Manager tool](https://github.com/E
 + 🌱 [Introduction](#-introduction)
 + 📝 [Usage](#-usage)
 + ⚙️ [Configuration file](#-configuration-file)
-+ 🏗 [Development](#-development)
 + ☎️ [Support](#-support)
 + 🪪 [License](#-license)
 

--- a/Enterwell.CI.Changelog.CLI.NPM/index.js
+++ b/Enterwell.CI.Changelog.CLI.NPM/index.js
@@ -27,7 +27,7 @@ if (process.platform !== 'win32') {
 // Ignoring 'node' and the name of the script
 const argsToForward = process.argv.slice(2);
 
-const childProcess = spawn(binaryPath, argsToForward, { stdio: 'inherit', shell: process.platform === 'win32' });
+const childProcess = spawn(binaryPath, argsToForward, { stdio: 'inherit' });
 
 childProcess.on("exit", (code) => {
   process.exit(code);


### PR DESCRIPTION
## Fixed
+ Properly escaping multi-word arguments